### PR TITLE
Issue-144: add template for github issue and pull request

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+Is this a question, feature request, or bug report?
+
+**QUESTION**
+
+Have you checked our documentation at http://distributedlog.apache.org/, If you could not find an answer there, please consider asking your question in our community forum at distributedlog-user@bookkeeper.apache.org, as it would benefit other members of our community.
+
+
+**FEATURE REQUEST**
+
+1. Please describe the feature you are requesting.
+
+2. Indicate the importance of this issue to you (blocker, must-have, should-have, nice-to-have). Are you currently using any workarounds to address this issue?
+
+3. Provide any additional detail on your proposed use case for this feature.
+
+4. If there are some sub-tasks using -[] for each subtask and create a corresponding issue to map to the sub task:
+- [ ] [sub-task1-issue-number](example_sub_issue1_link_here): sub-task1 discription here, 
+- [ ] [sub-task2-issue-number](example_sub_issue2_link_here): sub-task2 discription here,
+- ...
+
+
+**BUG REPORT**
+
+1. Please describe the issue you observed:
+
+- What did you do?
+
+- What did you expect to see?
+
+- What did you see instead?
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+Descriptions of the changes in this PR:
+
+(PR description content here)...
+
+> ---
+> Be sure to do all of the following to help us incorporate your contribution
+> quickly and easily:
+> 
+> - [ ] Make sure the PR title is formatted like:
+>     `<Issue-# or DL-#>: Description of pull request`
+>     `e.g. Issue-123: Description ...`
+>     `e.g. DL-1234: Description ...`
+> - [ ] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
+> - [ ] Replace '#' with in `<Issue-# or DL-#>` in the title with the actual Issue/JIRA number.
+> 
+> ---

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
             <exclude>docs/**/*</exclude>
             <exclude>website/**/*</exclude>
             <exclude>.git/**/*</exclude>
+            <exclude>.github/**/*</exclude>
             <exclude>.gitignore</exclude>
             <exclude>.idea/**/*</exclude>
             <exclude>dist/**/*</exclude>


### PR DESCRIPTION
This is part of the work to adopt github issue for issue management. 
Use similar template as bookkeeper.