### PR TITLE
DL-206: Delete the log should also delete the underline ledgers

### DIFF
--- a/distributedlog-core/src/main/java/org/apache/distributedlog/BKDistributedLogManager.java
+++ b/distributedlog-core/src/main/java/org/apache/distributedlog/BKDistributedLogManager.java
@@ -950,6 +950,10 @@ class BKDistributedLogManager implements DistributedLogManager {
      */
     @Override
     public void delete() throws IOException {
+        // delete the actual log stream and log segments
+        BKLogWriteHandler ledgerHandler = createWriteHandler(true);
+        ledgerHandler.deleteLog();
+        // delete the log stream metadata
         Utils.ioResult(driver.getLogStreamMetadataStore(WRITER)
                 .deleteLog(uri, getStreamName()));
     }

--- a/distributedlog-core/src/main/java/org/apache/distributedlog/BKLogWriteHandler.java
+++ b/distributedlog-core/src/main/java/org/apache/distributedlog/BKLogWriteHandler.java
@@ -362,6 +362,15 @@ class BKLogWriteHandler extends BKLogHandler {
     }
 
     /**
+     * Delete the whole log and all log segments under the log
+     */
+    void deleteLog() throws IOException {
+        lock.checkOwnershipAndReacquire();
+        Utils.ioResult(purgeLogSegmentsOlderThanTxnId(-1));
+        Utils.closeQuietly(lock);
+    }
+
+    /**
      * The caller could call this before any actions, which to hold the lock for
      * the write handler of its whole lifecycle. The lock will only be released
      * when closing the write handler.


### PR DESCRIPTION
Problem:
We're not deleting the ledgers when we delete the whole log stream using dlm.delete() API. This would cause a lot of garbage/orphan ledgers in Bookkeeper.

The fix is to delete the ledger when we delete the log stream. Also added a test to validate.
> ---
> Be sure to do all of the following to help us incorporate your contribution
> quickly and easily:
> 
> - [ ] Make sure the PR title is formatted like:
>     `<Issue-# or DL-#>: Description of pull request`
>     `e.g. Issue-123: Description ...`
>     `e.g. DL-1234: Description ...`
> - [ ] Make sure tests pass via `mvn clean apache-rat:check install findbugs:check`.
> - [ ] Replace '#' with in `<Issue-# or DL-#>` in the title with the actual Issue/JIRA number.
> 
> ---
