### PR TITLE
Issue 157: Introduce JMH for micro benchmarking

### DIFF
--- a/distributedlog-build-tools/src/main/resources/distributedlog/findbugsExclude.xml
+++ b/distributedlog-build-tools/src/main/resources/distributedlog/findbugsExclude.xml
@@ -1,0 +1,23 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+//-->
+<FindBugsFilter>
+  <Match>
+    <!-- generated code, we can't be held responsible for findbugs in it //-->
+    <Class name="~org\.apache\.distributedlog\.tests\.generated.*" />
+  </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
     <module>distributedlog-benchmark</module>
     <module>distributedlog-tutorials</module>
     <module>distributedlog-core-twitter</module>
+    <module>tests</module>
   </modules>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -108,6 +109,7 @@
     <freebuilder.version>1.12.3</freebuilder.version>
     <guava.version>20.0</guava.version>
     <jetty.version>8.1.19.v20160209</jetty.version>
+    <jmh.version>1.19</jmh.version>
     <jmock.version>2.8.2</jmock.version>
     <junit.version>4.8.1</junit.version>
     <libthrift.version>0.5.0-1</libthrift.version>
@@ -127,6 +129,7 @@
     <maven-assembly-plugin.version>2.2.1</maven-assembly-plugin.version>
     <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
+    <maven-deploy-plugin.version>2.7</maven-deploy-plugin.version>
     <maven-jar-plugin.version>2.2</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>2.8</maven-javadoc-plugin.version>
     <maven-shade-plugin.version>2.4.3</maven-shade-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,9 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
         <version>${findbugs-maven-plugin.version}</version>
+        <configuration>
+          <excludeFilterFile>${session.executionRootDirectory}/distributedlog-build-tools/src/main/resources/distributedlog/findbugsExclude.xml</excludeFilterFile>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -238,6 +241,7 @@
             <exclude>OWNERS</exclude>
             <exclude>CONFIG.ini</exclude>
             <exclude>**/**.md</exclude>
+            <exclude>**/**.iml</exclude>
             <exclude>scripts/dev/reviewers</exclude>
             <exclude>**/dependency-reduced-pom.xml</exclude>
             <exclude>**/org/apache/distributedlog/thrift/*</exclude>

--- a/tests/jmh-0.4/pom.xml
+++ b/tests/jmh-0.4/pom.xml
@@ -95,6 +95,10 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/tests/jmh-0.4/pom.xml
+++ b/tests/jmh-0.4/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.distributedlog.tests</groupId>
+    <artifactId>tests-parent</artifactId>
+    <version>0.5.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent> 
+  <artifactId>jmh-test-0.4</artifactId>
+  <name>Apache DistributedLog :: Tests :: JMH Benchmark (0.4.0-incubating)</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.distributedlog</groupId>
+      <artifactId>distributedlog-core_2.11</artifactId>
+      <version>0.4.0-incubating</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <!--
+        Name of the benchmark Uber-JAR to generate.
+      -->
+    <uberjar.name>jmh-benchmarks-0.4.0</uberjar.name>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven-shade-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${uberjar.name}</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <!--
+                    Shading signed JARs will fail without this.
+                    http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                  -->
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/jmh-0.4/src/main/java/org/apache/distributedlog/tests/CompressionBenchmark.java
+++ b/tests/jmh-0.4/src/main/java/org/apache/distributedlog/tests/CompressionBenchmark.java
@@ -1,0 +1,99 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.distributedlog.tests;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.stats.OpStatsLogger;
+import org.apache.distributedlog.io.CompressionCodec;
+import org.apache.distributedlog.io.CompressionCodec.Type;
+import org.apache.distributedlog.io.CompressionUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Benchmarking serialization and deserilization.
+ */
+@BenchmarkMode({ Mode.Throughput })
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+public class CompressionBenchmark {
+
+    @Param({ "10", "100", "1000", "10000" })
+    int size;
+
+    byte[] entry;
+    byte[] compressedLz4;
+    byte[] compressedNone;
+    CompressionCodec codecLz4;
+    CompressionCodec codecNone;
+    OpStatsLogger opStatsLogger;
+
+    @Setup
+    public void prepare() {
+        Random r = new Random(System.currentTimeMillis());
+        this.entry = new byte[this.size];
+        r.nextBytes(entry);
+
+        this.codecLz4 = CompressionUtils.getCompressionCodec(Type.LZ4);
+        this.codecNone = CompressionUtils.getCompressionCodec(Type.NONE);
+        this.opStatsLogger = NullStatsLogger.INSTANCE.getOpStatsLogger("");
+        this.compressedLz4 = codecLz4.compress(entry, 0, entry.length, opStatsLogger);
+        this.compressedNone = codecNone.compress(entry, 0, entry.length, opStatsLogger);
+    }
+
+
+    @Benchmark
+    public void testCompressLZ4() throws Exception {
+        testCompress(codecLz4);
+    }
+
+    @Benchmark
+    public void testCompressNone() throws Exception {
+        testCompress(codecNone);
+    }
+
+    private void testCompress(CompressionCodec codec) {
+        codec.compress(entry, 0, entry.length, opStatsLogger);
+    }
+
+    @Benchmark
+    public void testDecompressLZ4() throws Exception {
+        testDecompress(codecLz4, compressedLz4);
+    }
+
+    @Benchmark
+    public void testDecompressNone() throws Exception {
+        testDecompress(codecNone, compressedNone);
+    }
+
+    private void testDecompress(CompressionCodec codec, byte[] compressed) {
+        codec.decompress(compressed, 0, compressed.length, opStatsLogger);
+    }
+
+}

--- a/tests/jmh/pom.xml
+++ b/tests/jmh/pom.xml
@@ -95,6 +95,10 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>findbugs-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/tests/jmh/pom.xml
+++ b/tests/jmh/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.distributedlog.tests</groupId>
+    <artifactId>tests-parent</artifactId>
+    <version>0.5.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent> 
+  <artifactId>jmh-test</artifactId>
+  <name>Apache DistributedLog :: Tests :: JMH Benchmark</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.distributedlog</groupId>
+      <artifactId>distributedlog-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${jmh.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${jmh.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <!--
+        Name of the benchmark Uber-JAR to generate.
+      -->
+    <uberjar.name>jmh-benchmarks</uberjar.name>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven-shade-plugin.version}</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>${uberjar.name}</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+              <filters>
+                <filter>
+                  <!--
+                    Shading signed JARs will fail without this.
+                    http://stackoverflow.com/questions/999489/invalid-signature-file-when-attempting-to-run-a-jar
+                  -->
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/jmh/src/main/java/org/apache/distributedlog/tests/CompressionBenchmark.java
+++ b/tests/jmh/src/main/java/org/apache/distributedlog/tests/CompressionBenchmark.java
@@ -1,0 +1,99 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.distributedlog.tests;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.stats.OpStatsLogger;
+import org.apache.distributedlog.io.CompressionCodec;
+import org.apache.distributedlog.io.CompressionCodec.Type;
+import org.apache.distributedlog.io.CompressionUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Benchmarking serialization and deserilization.
+ */
+@BenchmarkMode({ Mode.Throughput })
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+public class CompressionBenchmark {
+
+    @Param({ "10", "100", "1000", "10000" })
+    int size;
+
+    byte[] entry;
+    byte[] compressedLz4;
+    byte[] compressedNone;
+    CompressionCodec codecLz4;
+    CompressionCodec codecNone;
+    OpStatsLogger opStatsLogger;
+
+    @Setup
+    public void prepare() {
+        Random r = new Random(System.currentTimeMillis());
+        this.entry = new byte[this.size];
+        r.nextBytes(entry);
+
+        this.codecLz4 = CompressionUtils.getCompressionCodec(Type.LZ4);
+        this.codecNone = CompressionUtils.getCompressionCodec(Type.NONE);
+        this.opStatsLogger = NullStatsLogger.INSTANCE.getOpStatsLogger("");
+        this.compressedLz4 = codecLz4.compress(entry, 0, entry.length, opStatsLogger);
+        this.compressedNone = codecNone.compress(entry, 0, entry.length, opStatsLogger);
+    }
+
+
+    @Benchmark
+    public void testCompressLZ4() throws Exception {
+        testCompress(codecLz4);
+    }
+
+    @Benchmark
+    public void testCompressNone() throws Exception {
+        testCompress(codecNone);
+    }
+
+    private void testCompress(CompressionCodec codec) {
+        codec.compress(entry, 0, entry.length, opStatsLogger);
+    }
+
+    @Benchmark
+    public void testDecompressLZ4() throws Exception {
+        testDecompress(codecLz4, compressedLz4);
+    }
+
+    @Benchmark
+    public void testDecompressNone() throws Exception {
+        testDecompress(codecNone, compressedNone);
+    }
+
+    private void testDecompress(CompressionCodec codec, byte[] compressed) {
+        codec.decompress(compressed, 0, compressed.length, opStatsLogger);
+    }
+
+}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <packaging>pom</packaging>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.distributedlog</groupId>
+    <artifactId>distributedlog</artifactId>
+    <version>0.5.0-SNAPSHOT</version>
+  </parent>
+  <groupId>org.apache.distributedlog.tests</groupId>
+  <artifactId>tests-parent</artifactId>
+  <name>Apache BookKeeper :: Tests</name>
+  <modules>
+    <module>jmh</module>
+    <module>jmh-0.4</module>
+  </modules>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>${maven-deploy-plugin.version}</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Descriptions of the changes in this PR:

- add a `tests/jmh` and `tests/jmh-0.4` module for micro-benchmarking
- `tests/jmh` is to benchmark latest master
- `tests/jmh-0.4` is to benchmark `0.4.0-incubating`
- add benchmark for compression