### PR TITLE
Issue 156: Provide a shading jar for distributedlog-core

### DIFF
--- a/distributedlog-core/pom.xml
+++ b/distributedlog-core/pom.xml
@@ -48,6 +48,10 @@
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -76,6 +80,10 @@
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -168,6 +176,7 @@
         </configuration>
         <executions>
           <execution>
+            <id>shade-thrift</id>
             <phase>package</phase>
             <goals>
               <goal>shade</goal>
@@ -183,7 +192,131 @@
               <relocations>
                 <relocation>
                   <pattern>org.apache.thrift</pattern>
-                  <shadedPattern>dl-shade.org.apache.thrift</shadedPattern>
+                  <shadedPattern>dlshade.org.apache.thrift</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+          <execution>
+            <id>shade-all</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>shaded</shadedClassifierName>
+              <minimizeJar>true</minimizeJar>
+              <artifactSet>
+                <includes>
+
+                  <include>commons-beanutils:commons-beanutils</include>
+                  <include>commons-beanutils:commons-beanutils-core</include>
+                  <include>commons-codec:commons-codec</include>
+                  <include>commons-cli:commons-cli</include>
+                  <include>commons-configuration:commons-configuration</include>
+                  <include>commons-collections:commons-collections</include>
+                  <include>commons-digester:commons-digester</include>
+                  <include>commons-io:commons-io</include>
+                  <include>commons-lang:commons-lang</include>
+                  <include>commons-logging:commons-logging</include>
+                  <include>com.google.guava:guava</include>
+                  <include>io.netty:netty</include>
+                  <include>io.netty:netty-all</include>
+                  <include>io.netty:netty-buffer</include>
+                  <include>io.netty:netty-common</include>
+                  <include>io.netty:netty-tcnative-boringssl-static</include>
+                  <include>net.java.dev.jna:jna</include>
+                  <include>net.jpountz.lz4:lz4</include>
+                  <include>org.apache.bookkeeper.stats:bookkeeper-stats-api</include>
+                  <include>org.apache.bookkeeper:bookkeeper-server</include>
+                  <include>org.apache.commons:commons-lang3</include>
+                  <include>org.apache.distributedlog:distributedlog-common</include>
+                  <include>org.apache.distributedlog:distributedlog-protocol</include>
+                  <include>org.apache.httpcomponents:httpclient</include>
+                  <include>org.apache.httpcomponents:httpcore</include>
+                  <include>org.apache.thrift:libthrift</include>
+                  <include>org.apache.zookeeper:zookeeper</include>
+                  <include>org.inferred:freebuilder</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>net.jpountz.lz4:lz4</artifact>
+                  <includes>
+                    <include>**</include>
+                  </includes>
+                </filter>
+              </filters>
+              <relocations>
+                <!-- apache commons --> 
+                <relocation>
+                  <pattern>org.apache.commons</pattern>
+                  <shadedPattern>dlshade.org.apache.commons</shadedPattern>
+                </relocation>
+                <!-- apache httpcomponents -->
+                <relocation>
+                  <pattern>org.apache.httpcomponents</pattern>
+                  <shadedPattern>dlshade.org.apache.httpcomponents</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.http</pattern>
+                  <shadedPattern>dlshade.org.apache.http</shadedPattern>
+                </relocation>
+                <!-- apache thrift -->
+                <relocation>
+                  <pattern>org.apache.thrift</pattern>
+                  <shadedPattern>dlshade.org.apache.thrift</shadedPattern>
+                </relocation>
+                <!-- apache zookeeper -->
+                <relocation>
+                  <pattern>org.apache.zookeeper</pattern>
+                  <shadedPattern>dlshade.org.apache.zookeeper</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.jute</pattern>
+                  <shadedPattern>dlshade.org.apache.jute</shadedPattern>
+                </relocation>
+                <!-- freebuilder -->
+                <relocation>
+                  <pattern>org.inferred.freebuilder</pattern>
+                  <shadedPattern>dlshade.org.inferred.freebuilder</shadedPattern>
+                </relocation>
+                <!-- jna -->
+                <relocation>
+                  <pattern>com.sun.jna</pattern>
+                  <shadedPattern>dlshade.com.sun.jna</shadedPattern>
+                </relocation>
+                <!-- guava -->
+                <relocation>
+                  <pattern>com.google</pattern>
+                  <shadedPattern>dlshade.com.google</shadedPattern>
+                </relocation>
+                <!-- netty -->
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <shadedPattern>dlshade.io.netty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.jboss.netty</pattern>
+                  <shadedPattern>dlshade.org.jboss.netty</shadedPattern>
+                </relocation>
+                <!-- lz4 -->
+                <relocation>
+                  <pattern>net.jpountz</pattern>
+                  <shadedPattern>dlshade.net.jpountz</shadedPattern>
+                </relocation>
+                <!-- bookkeeper -->
+                <relocation>
+                  <pattern>org.apache.bookkeeper</pattern>
+                  <shadedPattern>org.apache.bookkeeper</shadedPattern>
+                </relocation>
+                <!-- distributedlog -->
+                <relocation>
+                  <pattern>org.apache.distributedlog</pattern>
+                  <shadedPattern>org.apache.distributedlog</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -30,6 +30,7 @@
   <modules>
     <module>jmh</module>
     <module>jmh-0.4</module>
+    <module>shading</module>
   </modules>
   <build>
     <plugins>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -30,7 +30,6 @@
   <modules>
     <module>jmh</module>
     <module>jmh-0.4</module>
-    <module>shading</module>
   </modules>
   <build>
     <plugins>


### PR DESCRIPTION
Descriptions of the changes in this PR:

- provide a shade-all jar (shading all the dependencies) for distributedlog-core. the `shade-all` jar is classified as `shaded`.