### PR TITLE
Issue 185: Thrift version conflicts and use heap bytebuffer for thrift serialization

### DIFF
--- a/distributedlog-core-twitter/pom.xml
+++ b/distributedlog-core-twitter/pom.xml
@@ -29,6 +29,12 @@
       <groupId>org.apache.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
       <version>${project.parent.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.thrift</groupId>
+          <artifactId>libthrift</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>

--- a/distributedlog-proxy-client/src/main/java/org/apache/distributedlog/client/DistributedLogClientImpl.java
+++ b/distributedlog-proxy-client/src/main/java/org/apache/distributedlog/client/DistributedLogClientImpl.java
@@ -397,14 +397,27 @@ public class DistributedLogClientImpl implements DistributedLogClient, MonitorSe
 
         WriteOp(final String name, final ByteBuf dataBuf) {
             super(name, clientStats.getOpStats("write"));
-            this.dataBuf = dataBuf;
-            this.data = dataBuf.nioBuffer();
+            if (dataBuf.hasArray()) {
+                this.dataBuf = dataBuf;
+                this.data = dataBuf.nioBuffer();
+            } else {
+                // thrift only takes heap byte buffer
+                this.dataBuf = Unpooled.copiedBuffer(dataBuf);
+                dataBuf.release();
+                this.data = this.dataBuf.nioBuffer();
+            }
         }
 
         WriteOp(final String name, final ByteBuffer data) {
             super(name, clientStats.getOpStats("write"));
-            this.data = data;
-            this.dataBuf = Unpooled.wrappedBuffer(data);
+            if (data.hasArray()) {
+                this.data = data;
+                this.dataBuf = Unpooled.wrappedBuffer(data);
+            } else {
+                // thrift only takes heap byte buffer
+                this.dataBuf = Unpooled.copiedBuffer(data);
+                this.data = this.dataBuf.nioBuffer();
+            }
         }
 
         @Override

--- a/distributedlog-proxy-server/pom.xml
+++ b/distributedlog-proxy-server/pom.xml
@@ -45,6 +45,12 @@
       <groupId>org.apache.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
       <version>${project.parent.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.thrift</groupId>
+          <artifactId>libthrift</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>

--- a/distributedlog-tutorials/distributedlog-basic/pom.xml
+++ b/distributedlog-tutorials/distributedlog-basic/pom.xml
@@ -36,6 +36,12 @@
       <groupId>org.apache.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
       <version>${project.parent.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.thrift</groupId>
+          <artifactId>libthrift</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.distributedlog</groupId>

--- a/distributedlog-tutorials/distributedlog-messaging/pom.xml
+++ b/distributedlog-tutorials/distributedlog-messaging/pom.xml
@@ -36,6 +36,12 @@
       <groupId>org.apache.distributedlog</groupId>
       <artifactId>distributedlog-core</artifactId>
       <version>${project.parent.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.thrift</groupId>
+          <artifactId>libthrift</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.distributedlog</groupId>


### PR DESCRIPTION

Descriptions of the changes in this PR:

- it seems that shade plugin doesn't work well with sub-modules. even the libthrift-9 was shaded, it is still imported/included in the sub-modules, causing the version conflict. Explicitly exclude the libthrift from distributedlog-core.

- thrift serialization is using heap bytebuffer. so if a bytebuffer is direct, the serialization will fail. add a change to check if bytebuffer is heap, if bytebuffer is not heap, copy the content into a heap buffer. this is not good for performance, but we don't have any other choices because the limitation comes from libthrift. 