### PR TITLE
Issue 196: Bump bk version to 4.6.0-SNAPSHOT

### DIFF
--- a/distributedlog-core/src/main/java/org/apache/distributedlog/bk/LedgerAllocatorPool.java
+++ b/distributedlog-core/src/main/java/org/apache/distributedlog/bk/LedgerAllocatorPool.java
@@ -26,16 +26,14 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-
 import java.util.concurrent.CountDownLatch;
-
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.bookkeeper.client.LedgerHandle;
-import org.apache.bookkeeper.meta.ZkVersion;
 import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.distributedlog.BookKeeperClient;
 import org.apache.distributedlog.DistributedLogConfiguration;
@@ -43,18 +41,14 @@ import org.apache.distributedlog.ZooKeeperClient;
 import org.apache.distributedlog.common.concurrent.FutureEventListener;
 import org.apache.distributedlog.common.concurrent.FutureUtils;
 import org.apache.distributedlog.exceptions.DLInterruptedException;
-
 import org.apache.distributedlog.util.Transaction;
 import org.apache.distributedlog.util.Utils;
-
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
 
 /**
  * LedgerAllocator impl.
@@ -203,7 +197,7 @@ public class LedgerAllocatorPool implements LedgerAllocator {
                     return;
                 }
                 Versioned<byte[]> allocatorData =
-                        new Versioned<byte[]>(data, new ZkVersion(stat.getVersion()));
+                        new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
                 SimpleLedgerAllocator allocator =
                         new SimpleLedgerAllocator(path, allocatorData, quorumConfigProvider, zkc, bkc);
                 allocator.start();
@@ -262,7 +256,7 @@ public class LedgerAllocatorPool implements LedgerAllocator {
                     SimpleLedgerAllocator newAllocator = null;
                     if (KeeperException.Code.OK.intValue() == rc) {
                         Versioned<byte[]> allocatorData =
-                                new Versioned<byte[]>(data, new ZkVersion(stat.getVersion()));
+                                new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
                         logger.info("Rescuing ledger allocator {}.", path);
                         newAllocator = new SimpleLedgerAllocator(path, allocatorData, quorumConfigProvider, zkc, bkc);
                         newAllocator.start();
@@ -448,6 +442,6 @@ public class LedgerAllocatorPool implements LedgerAllocator {
             allocatorsToDelete,
             allocator -> allocator.delete(),
             scheduledExecutorService
-        ).thenCompose(values -> Utils.zkDelete(zkc, poolPath, new ZkVersion(-1)));
+        ).thenCompose(values -> Utils.zkDelete(zkc, poolPath, new LongVersion(-1)));
     }
 }

--- a/distributedlog-core/src/main/java/org/apache/distributedlog/impl/metadata/ZKLogStreamMetadataStore.java
+++ b/distributedlog-core/src/main/java/org/apache/distributedlog/impl/metadata/ZKLogStreamMetadataStore.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.distributedlog.metadata.LogMetadata.*;
 
 import com.google.common.base.Optional;
-
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.net.URI;
@@ -30,15 +29,13 @@ import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-
 import java.util.function.Function;
-import org.apache.bookkeeper.meta.ZkVersion;
 import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.distributedlog.DistributedLogConfiguration;
 import org.apache.distributedlog.DistributedLogConstants;
 import org.apache.distributedlog.ZooKeeperClient;
-
 import org.apache.distributedlog.common.concurrent.FutureUtils;
 import org.apache.distributedlog.common.util.PermitManager;
 import org.apache.distributedlog.common.util.SchedulerUtils;
@@ -59,16 +56,12 @@ import org.apache.distributedlog.metadata.LogMetadata;
 import org.apache.distributedlog.metadata.LogMetadataForReader;
 import org.apache.distributedlog.metadata.LogMetadataForWriter;
 import org.apache.distributedlog.metadata.LogStreamMetadataStore;
-
-
 import org.apache.distributedlog.util.DLUtils;
 import org.apache.distributedlog.util.OrderedScheduler;
 import org.apache.distributedlog.util.Transaction;
 import org.apache.distributedlog.util.Utils;
 import org.apache.distributedlog.zk.LimitedPermitManager;
 import org.apache.distributedlog.zk.ZKTransaction;
-
-
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -81,9 +74,6 @@ import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
-
 
 /**
  * zookeeper based {@link LogStreamMetadataStore}.
@@ -458,7 +448,7 @@ public class ZKLogStreamMetadataStore implements LogStreamMetadataStore {
                         if (null == dataCreated) {
                             finalMetadatas.add(metadatas.get(i));
                         } else {
-                            finalMetadatas.add(new Versioned<byte[]>(dataCreated, new ZkVersion(0)));
+                            finalMetadatas.add(new Versioned<byte[]>(dataCreated, new LongVersion(0)));
                         }
                     }
                     promise.complete(finalMetadatas);

--- a/distributedlog-core/src/main/java/org/apache/distributedlog/impl/subscription/ZKSubscriptionsStore.java
+++ b/distributedlog-core/src/main/java/org/apache/distributedlog/impl/subscription/ZKSubscriptionsStore.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import org.apache.bookkeeper.meta.ZkVersion;
+import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.distributedlog.DLSN;
 import org.apache.distributedlog.ZooKeeperClient;
@@ -33,7 +33,6 @@ import org.apache.distributedlog.api.subscription.SubscriptionStateStore;
 import org.apache.distributedlog.api.subscription.SubscriptionsStore;
 import org.apache.distributedlog.common.concurrent.FutureUtils;
 import org.apache.distributedlog.exceptions.DLInterruptedException;
-
 import org.apache.distributedlog.util.Utils;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.KeeperException;
@@ -137,7 +136,7 @@ public class ZKSubscriptionsStore implements SubscriptionsStore {
     public CompletableFuture<Boolean> deleteSubscriber(String subscriberId) {
         subscribers.remove(subscriberId);
         String path = getSubscriberZKPath(subscriberId);
-        return Utils.zkDeleteIfNotExist(zkc, path, new ZkVersion(-1));
+        return Utils.zkDeleteIfNotExist(zkc, path, new LongVersion(-1L));
     }
 
     @Override

--- a/distributedlog-core/src/main/java/org/apache/distributedlog/zk/ZKVersionedSetOp.java
+++ b/distributedlog-core/src/main/java/org/apache/distributedlog/zk/ZKVersionedSetOp.java
@@ -18,7 +18,7 @@
 package org.apache.distributedlog.zk;
 
 import javax.annotation.Nullable;
-import org.apache.bookkeeper.meta.ZkVersion;
+import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.distributedlog.util.Transaction.OpListener;
 import org.apache.zookeeper.KeeperException;
@@ -44,7 +44,7 @@ public class ZKVersionedSetOp extends ZKOp {
         assert(opResult instanceof OpResult.SetDataResult);
         OpResult.SetDataResult setDataResult = (OpResult.SetDataResult) opResult;
         if (null != listener) {
-            listener.onCommit(new ZkVersion(setDataResult.getStat().getVersion()));
+            listener.onCommit(new LongVersion(setDataResult.getStat().getVersion()));
         }
     }
 

--- a/distributedlog-core/src/test/java/org/apache/distributedlog/TestDistributedLogConfiguration.java
+++ b/distributedlog-core/src/test/java/org/apache/distributedlog/TestDistributedLogConfiguration.java
@@ -84,7 +84,7 @@ public class TestDistributedLogConfiguration {
     @Test(timeout = 20000)
     public void loadStreamConfNullOverrides() throws Exception {
         DistributedLogConfiguration conf = new DistributedLogConfiguration();
-        DistributedLogConfiguration confClone = (DistributedLogConfiguration) conf.clone();
+        DistributedLogConfiguration confClone = new DistributedLogConfiguration();
         Optional<DistributedLogConfiguration> streamConfiguration = Optional.absent();
         conf.loadStreamConf(streamConfiguration);
 

--- a/distributedlog-core/src/test/java/org/apache/distributedlog/TestLogSegmentsZK.java
+++ b/distributedlog-core/src/test/java/org/apache/distributedlog/TestLogSegmentsZK.java
@@ -17,14 +17,14 @@
  */
 package org.apache.distributedlog;
 
-
 import static com.google.common.base.Charsets.UTF_8;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
-import org.apache.bookkeeper.meta.ZkVersion;
+import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.distributedlog.api.DistributedLogManager;
 import org.apache.distributedlog.api.namespace.Namespace;
@@ -40,9 +40,6 @@ import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-
-
 /**
  * Test Cases for LogSegmentsZK.
  */
@@ -56,7 +53,7 @@ public class TestLogSegmentsZK extends TestDistributedLogBase {
         String logSegmentsPath = LogMetadata.getLogSegmentsPath(
                 uri, streamName, conf.getUnpartitionedStreamName());
         byte[] data = zkc.get().getData(logSegmentsPath, false, stat);
-        Versioned<byte[]> maxLSSNData = new Versioned<byte[]>(data, new ZkVersion(stat.getVersion()));
+        Versioned<byte[]> maxLSSNData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
         return new MaxLogSegmentSequenceNo(maxLSSNData);
     }
 

--- a/distributedlog-core/src/test/java/org/apache/distributedlog/bk/TestLedgerAllocator.java
+++ b/distributedlog-core/src/test/java/org/apache/distributedlog/bk/TestLedgerAllocator.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Charsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.net.URI;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -30,26 +31,22 @@ import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
 import org.apache.bookkeeper.client.LedgerHandle;
-import org.apache.bookkeeper.meta.ZkVersion;
+import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.distributedlog.BookKeeperClient;
 import org.apache.distributedlog.BookKeeperClientBuilder;
 import org.apache.distributedlog.DistributedLogConfiguration;
 import org.apache.distributedlog.TestDistributedLogBase;
 import org.apache.distributedlog.TestZooKeeperClientBuilder;
-
 import org.apache.distributedlog.ZooKeeperClient;
 import org.apache.distributedlog.bk.SimpleLedgerAllocator.AllocationException;
 import org.apache.distributedlog.bk.SimpleLedgerAllocator.Phase;
 import org.apache.distributedlog.common.annotations.DistributedLogAnnotations;
-
-
 import org.apache.distributedlog.exceptions.ZKException;
 import org.apache.distributedlog.util.Transaction.OpListener;
 import org.apache.distributedlog.util.Utils;
 import org.apache.distributedlog.zk.DefaultZKOp;
 import org.apache.distributedlog.zk.ZKTransaction;
-
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Op;
@@ -63,9 +60,6 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
-
 
 /**
  * TestLedgerAllocator.
@@ -174,7 +168,7 @@ public class TestLedgerAllocator extends TestDistributedLogBase {
         zkc.get().create(allocationPath, new byte[0], ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
         Stat stat = new Stat();
         byte[] data = zkc.get().getData(allocationPath, false, stat);
-        Versioned<byte[]> allocationData = new Versioned<byte[]>(data, new ZkVersion(stat.getVersion()));
+        Versioned<byte[]> allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
 
         SimpleLedgerAllocator allocator1 =
                 new SimpleLedgerAllocator(allocationPath, allocationData, newQuorumConfigProvider(dlConf), zkc, bkc);
@@ -241,7 +235,7 @@ public class TestLedgerAllocator extends TestDistributedLogBase {
         Stat stat = new Stat();
         byte[] data = zkc.get().getData(allocationPath, false, stat);
 
-        Versioned<byte[]> allocationData = new Versioned<byte[]>(data, new ZkVersion(stat.getVersion()));
+        Versioned<byte[]> allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
 
         SimpleLedgerAllocator allocator1 =
                 new SimpleLedgerAllocator(allocationPath, allocationData, newQuorumConfigProvider(dlConf), zkc, bkc);
@@ -253,7 +247,7 @@ public class TestLedgerAllocator extends TestDistributedLogBase {
         // Second allocator kicks in
         stat = new Stat();
         data = zkc.get().getData(allocationPath, false, stat);
-        allocationData = new Versioned<byte[]>(data, new ZkVersion(stat.getVersion()));
+        allocationData = new Versioned<byte[]>(data, new LongVersion(stat.getVersion()));
         SimpleLedgerAllocator allocator2 =
                 new SimpleLedgerAllocator(allocationPath, allocationData, newQuorumConfigProvider(dlConf), zkc, bkc);
         allocator2.allocate();

--- a/distributedlog-core/src/test/java/org/apache/distributedlog/impl/TestZKLogSegmentMetadataStore.java
+++ b/distributedlog-core/src/test/java/org/apache/distributedlog/impl/TestZKLogSegmentMetadataStore.java
@@ -17,8 +17,14 @@
  */
 package org.apache.distributedlog.impl;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.google.common.collect.Lists;
 import java.net.URI;
 import java.util.Collections;
@@ -27,7 +33,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.bookkeeper.meta.ZkVersion;
+import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Version;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.distributedlog.DLMTestUtil;
@@ -45,7 +51,6 @@ import org.apache.distributedlog.metadata.LogMetadataForWriter;
 import org.apache.distributedlog.util.DLUtils;
 import org.apache.distributedlog.util.OrderedScheduler;
 import org.apache.distributedlog.util.Transaction;
-
 import org.apache.distributedlog.util.Utils;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -58,10 +63,6 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
-
-
 
 /**
  * Test ZK based log segment metadata store.
@@ -637,7 +638,7 @@ public class TestZKLogSegmentMetadataStore extends TestDistributedLogBase {
     @Test(timeout = 60000)
     public void testStoreMaxLogSegmentSequenceNumber() throws Exception {
         Transaction<Object> updateTxn = lsmStore.transaction();
-        Versioned<Long> value = new Versioned<Long>(999L, new ZkVersion(0));
+        Versioned<Long> value = new Versioned<Long>(999L, new LongVersion(0));
         final CompletableFuture<Version> result = new CompletableFuture<Version>();
         LogMetadata metadata = mock(LogMetadata.class);
         when(metadata.getLogSegmentsPath()).thenReturn(rootZkPath);
@@ -654,7 +655,7 @@ public class TestZKLogSegmentMetadataStore extends TestDistributedLogBase {
             }
         });
         Utils.ioResult(updateTxn.execute());
-        assertEquals(1, ((ZkVersion) Utils.ioResult(result)).getZnodeVersion());
+        assertEquals(1L, ((LongVersion) Utils.ioResult(result)).getLongVersion());
         Stat stat = new Stat();
         byte[] data = zkc.get().getData(rootZkPath, false, stat);
         assertEquals(999L, DLUtils.deserializeLogSegmentSequenceNumber(data));
@@ -664,7 +665,7 @@ public class TestZKLogSegmentMetadataStore extends TestDistributedLogBase {
     @Test(timeout = 60000)
     public void testStoreMaxLogSegmentSequenceNumberBadVersion() throws Exception {
         Transaction<Object> updateTxn = lsmStore.transaction();
-        Versioned<Long> value = new Versioned<Long>(999L, new ZkVersion(10));
+        Versioned<Long> value = new Versioned<Long>(999L, new LongVersion(10));
         final CompletableFuture<Version> result = new CompletableFuture<Version>();
         LogMetadata metadata = mock(LogMetadata.class);
         when(metadata.getLogSegmentsPath()).thenReturn(rootZkPath);
@@ -701,7 +702,7 @@ public class TestZKLogSegmentMetadataStore extends TestDistributedLogBase {
     @Test(timeout = 60000)
     public void testStoreMaxLogSegmentSequenceNumberOnNonExistentPath() throws Exception {
         Transaction<Object> updateTxn = lsmStore.transaction();
-        Versioned<Long> value = new Versioned<Long>(999L, new ZkVersion(10));
+        Versioned<Long> value = new Versioned<Long>(999L, new LongVersion(10));
         final CompletableFuture<Version> result = new CompletableFuture<Version>();
         String nonExistentPath = rootZkPath + "/non-existent";
         LogMetadata metadata = mock(LogMetadata.class);
@@ -735,7 +736,7 @@ public class TestZKLogSegmentMetadataStore extends TestDistributedLogBase {
     @Test(timeout = 60000)
     public void testStoreMaxTxnId() throws Exception {
         Transaction<Object> updateTxn = lsmStore.transaction();
-        Versioned<Long> value = new Versioned<Long>(999L, new ZkVersion(0));
+        Versioned<Long> value = new Versioned<Long>(999L, new LongVersion(0));
         final CompletableFuture<Version> result = new CompletableFuture<Version>();
         LogMetadataForWriter metadata = mock(LogMetadataForWriter.class);
         when(metadata.getMaxTxIdPath()).thenReturn(rootZkPath);
@@ -752,7 +753,7 @@ public class TestZKLogSegmentMetadataStore extends TestDistributedLogBase {
             }
         });
         Utils.ioResult(updateTxn.execute());
-        assertEquals(1, ((ZkVersion) Utils.ioResult(result)).getZnodeVersion());
+        assertEquals(1L, ((LongVersion) Utils.ioResult(result)).getLongVersion());
         Stat stat = new Stat();
         byte[] data = zkc.get().getData(rootZkPath, false, stat);
         assertEquals(999L, DLUtils.deserializeTransactionId(data));
@@ -762,7 +763,7 @@ public class TestZKLogSegmentMetadataStore extends TestDistributedLogBase {
     @Test(timeout = 60000)
     public void testStoreMaxTxnIdBadVersion() throws Exception {
         Transaction<Object> updateTxn = lsmStore.transaction();
-        Versioned<Long> value = new Versioned<Long>(999L, new ZkVersion(10));
+        Versioned<Long> value = new Versioned<Long>(999L, new LongVersion(10));
         final CompletableFuture<Version> result = new CompletableFuture<Version>();
         LogMetadataForWriter metadata = mock(LogMetadataForWriter.class);
         when(metadata.getMaxTxIdPath()).thenReturn(rootZkPath);
@@ -799,7 +800,7 @@ public class TestZKLogSegmentMetadataStore extends TestDistributedLogBase {
     @Test(timeout = 60000)
     public void testStoreMaxTxnIdOnNonExistentPath() throws Exception {
         Transaction<Object> updateTxn = lsmStore.transaction();
-        Versioned<Long> value = new Versioned<Long>(999L, new ZkVersion(10));
+        Versioned<Long> value = new Versioned<Long>(999L, new LongVersion(10));
         final CompletableFuture<Version> result = new CompletableFuture<Version>();
         String nonExistentPath = rootZkPath + "/non-existent";
         LogMetadataForWriter metadata = mock(LogMetadataForWriter.class);

--- a/distributedlog-core/src/test/java/org/apache/distributedlog/impl/metadata/TestZKLogStreamMetadataStore.java
+++ b/distributedlog-core/src/test/java/org/apache/distributedlog/impl/metadata/TestZKLogStreamMetadataStore.java
@@ -19,12 +19,15 @@ package org.apache.distributedlog.impl.metadata;
 
 import static org.apache.distributedlog.impl.metadata.ZKLogStreamMetadataStore.*;
 import static org.apache.distributedlog.metadata.LogMetadata.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.collect.Lists;
 import java.net.URI;
 import java.util.List;
-import org.apache.bookkeeper.meta.ZkVersion;
 import org.apache.bookkeeper.util.ZkUtils;
+import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.distributedlog.DLMTestUtil;
 import org.apache.distributedlog.DistributedLogConfiguration;
@@ -38,10 +41,8 @@ import org.apache.distributedlog.api.namespace.NamespaceBuilder;
 import org.apache.distributedlog.exceptions.LogNotFoundException;
 import org.apache.distributedlog.metadata.DLMetadata;
 import org.apache.distributedlog.metadata.LogMetadataForWriter;
-
 import org.apache.distributedlog.util.DLUtils;
 import org.apache.distributedlog.util.Utils;
-
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.Transaction;
@@ -53,10 +54,6 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-
-
-
 
 /**
  * Test {@link ZKLogStreamMetadataStore}.
@@ -188,7 +185,7 @@ public class TestZKLogStreamMetadataStore extends ZooKeeperClusterTestCase {
 
         for (Versioned<byte[]> metadata : metadatas) {
             assertTrue(pathExists(metadata));
-            assertTrue(((ZkVersion) metadata.getVersion()).getZnodeVersion() >= 0);
+            assertTrue(((LongVersion) metadata.getVersion()).getLongVersion() >= 0L);
         }
 
         Versioned<byte[]> logSegmentsData = logMetadata.getMaxLSSNData();

--- a/distributedlog-core/src/test/java/org/apache/distributedlog/impl/metadata/TestZKLogStreamMetadataStoreUtils.java
+++ b/distributedlog-core/src/test/java/org/apache/distributedlog/impl/metadata/TestZKLogStreamMetadataStoreUtils.java
@@ -17,22 +17,22 @@
  */
 package org.apache.distributedlog.impl.metadata;
 
+import static org.apache.distributedlog.impl.metadata.ZKLogStreamMetadataStore.intToBytes;
+import static org.apache.distributedlog.impl.metadata.ZKLogStreamMetadataStore.processLogMetadatas;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
-import static org.apache.distributedlog.impl.metadata.ZKLogStreamMetadataStore.*;
-import static org.junit.Assert.*;
 import com.google.common.collect.Lists;
 import java.net.URI;
 import java.util.List;
-import org.apache.bookkeeper.meta.ZkVersion;
+import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.distributedlog.DLMTestUtil;
 import org.apache.distributedlog.exceptions.UnexpectedException;
 import org.apache.distributedlog.metadata.LogMetadata;
 import org.apache.distributedlog.metadata.LogMetadataForWriter;
 import org.apache.distributedlog.util.DLUtils;
-
 import org.junit.Test;
-
 
 /**
  * TestZKLogStreamMetadataStoreUtils.
@@ -63,7 +63,7 @@ public class TestZKLogStreamMetadataStoreUtils {
         List<Versioned<byte[]>> metadatas = Lists.newArrayList(
                 new Versioned<byte[]>(null, null),
                 new Versioned<byte[]>(null, null),
-                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new ZkVersion(1)),
+                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new LongVersion(1)),
                 new Versioned<byte[]>(null, null));
         processLogMetadatas(uri, logName, logIdentifier, metadatas, false);
     }
@@ -78,7 +78,7 @@ public class TestZKLogStreamMetadataStoreUtils {
         List<Versioned<byte[]>> metadatas = Lists.newArrayList(
                 new Versioned<byte[]>(null, null),
                 new Versioned<byte[]>(null, null),
-                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new ZkVersion(1)),
+                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new LongVersion(1)),
                 new Versioned<byte[]>(intToBytes(9999), null));
         processLogMetadatas(uri, logName, logIdentifier, metadatas, false);
     }
@@ -93,7 +93,7 @@ public class TestZKLogStreamMetadataStoreUtils {
         List<Versioned<byte[]>> metadatas = Lists.newArrayList(
                 new Versioned<byte[]>(null, null),
                 new Versioned<byte[]>(null, null),
-                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new ZkVersion(1)),
+                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new LongVersion(1)),
                 new Versioned<byte[]>(intToBytes(LogMetadata.LAYOUT_VERSION), null),
                 new Versioned<byte[]>(null, null));
         processLogMetadatas(uri, logName, logIdentifier, metadatas, false);
@@ -109,9 +109,9 @@ public class TestZKLogStreamMetadataStoreUtils {
         List<Versioned<byte[]>> metadatas = Lists.newArrayList(
                 new Versioned<byte[]>(null, null),
                 new Versioned<byte[]>(null, null),
-                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new ZkVersion(1)),
+                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new LongVersion(1)),
                 new Versioned<byte[]>(intToBytes(LogMetadata.LAYOUT_VERSION), null),
-                new Versioned<byte[]>(new byte[0], new ZkVersion(1)),
+                new Versioned<byte[]>(new byte[0], new LongVersion(1)),
                 new Versioned<byte[]>(null, null));
         processLogMetadatas(uri, logName, logIdentifier, metadatas, false);
     }
@@ -126,10 +126,10 @@ public class TestZKLogStreamMetadataStoreUtils {
         List<Versioned<byte[]>> metadatas = Lists.newArrayList(
                 new Versioned<byte[]>(null, null),
                 new Versioned<byte[]>(null, null),
-                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new ZkVersion(1)),
+                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new LongVersion(1)),
                 new Versioned<byte[]>(intToBytes(LogMetadata.LAYOUT_VERSION), null),
-                new Versioned<byte[]>(new byte[0], new ZkVersion(1)),
-                new Versioned<byte[]>(new byte[0], new ZkVersion(1)),
+                new Versioned<byte[]>(new byte[0], new LongVersion(1)),
+                new Versioned<byte[]>(new byte[0], new LongVersion(1)),
                 new Versioned<byte[]>(null, null));
         processLogMetadatas(uri, logName, logIdentifier, metadatas, false);
     }
@@ -144,11 +144,11 @@ public class TestZKLogStreamMetadataStoreUtils {
         List<Versioned<byte[]>> metadatas = Lists.newArrayList(
                 new Versioned<byte[]>(null, null),
                 new Versioned<byte[]>(null, null),
-                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new ZkVersion(1)),
+                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new LongVersion(1)),
                 new Versioned<byte[]>(intToBytes(LogMetadata.LAYOUT_VERSION), null),
-                new Versioned<byte[]>(new byte[0], new ZkVersion(1)),
-                new Versioned<byte[]>(new byte[0], new ZkVersion(1)),
-                new Versioned<byte[]>(DLUtils.serializeLogSegmentSequenceNumber(1L), new ZkVersion(1)),
+                new Versioned<byte[]>(new byte[0], new LongVersion(1)),
+                new Versioned<byte[]>(new byte[0], new LongVersion(1)),
+                new Versioned<byte[]>(DLUtils.serializeLogSegmentSequenceNumber(1L), new LongVersion(1)),
                 new Versioned<byte[]>(null, null));
         processLogMetadatas(uri, logName, logIdentifier, metadatas, true);
     }
@@ -161,16 +161,16 @@ public class TestZKLogStreamMetadataStoreUtils {
         String logName = "test-log";
         String logIdentifier = "<default>";
         Versioned<byte[]> maxTxnIdData =
-                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new ZkVersion(1));
+                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new LongVersion(1));
         Versioned<byte[]> logSegmentsData =
-                new Versioned<byte[]>(DLUtils.serializeLogSegmentSequenceNumber(1L), new ZkVersion(1));
+                new Versioned<byte[]>(DLUtils.serializeLogSegmentSequenceNumber(1L), new LongVersion(1));
         List<Versioned<byte[]>> metadatas = Lists.newArrayList(
                 new Versioned<byte[]>(null, null),
                 new Versioned<byte[]>(null, null),
                 maxTxnIdData,
                 new Versioned<byte[]>(intToBytes(LogMetadata.LAYOUT_VERSION), null),
-                new Versioned<byte[]>(new byte[0], new ZkVersion(1)),
-                new Versioned<byte[]>(new byte[0], new ZkVersion(1)),
+                new Versioned<byte[]>(new byte[0], new LongVersion(1)),
+                new Versioned<byte[]>(new byte[0], new LongVersion(1)),
                 logSegmentsData);
         LogMetadataForWriter metadata =
                 processLogMetadatas(uri, logName, logIdentifier, metadatas, false);
@@ -188,18 +188,18 @@ public class TestZKLogStreamMetadataStoreUtils {
         String logName = "test-log";
         String logIdentifier = "<default>";
         Versioned<byte[]> maxTxnIdData =
-                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new ZkVersion(1));
+                new Versioned<byte[]>(DLUtils.serializeTransactionId(1L), new LongVersion(1));
         Versioned<byte[]> logSegmentsData =
-                new Versioned<byte[]>(DLUtils.serializeLogSegmentSequenceNumber(1L), new ZkVersion(1));
+                new Versioned<byte[]>(DLUtils.serializeLogSegmentSequenceNumber(1L), new LongVersion(1));
         Versioned<byte[]> allocationData =
-                new Versioned<byte[]>(DLUtils.logSegmentId2Bytes(1L), new ZkVersion(1));
+                new Versioned<byte[]>(DLUtils.logSegmentId2Bytes(1L), new LongVersion(1));
         List<Versioned<byte[]>> metadatas = Lists.newArrayList(
                 new Versioned<byte[]>(null, null),
                 new Versioned<byte[]>(null, null),
                 maxTxnIdData,
                 new Versioned<byte[]>(intToBytes(LogMetadata.LAYOUT_VERSION), null),
-                new Versioned<byte[]>(new byte[0], new ZkVersion(1)),
-                new Versioned<byte[]>(new byte[0], new ZkVersion(1)),
+                new Versioned<byte[]>(new byte[0], new LongVersion(1)),
+                new Versioned<byte[]>(new byte[0], new LongVersion(1)),
                 logSegmentsData,
                 allocationData);
         LogMetadataForWriter metadata =

--- a/distributedlog-core/src/test/java/org/apache/distributedlog/util/TestUtils.java
+++ b/distributedlog-core/src/test/java/org/apache/distributedlog/util/TestUtils.java
@@ -18,10 +18,14 @@
 package org.apache.distributedlog.util;
 
 import static com.google.common.base.Charsets.UTF_8;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import com.google.common.base.Optional;
 import java.util.concurrent.CountDownLatch;
-import org.apache.bookkeeper.meta.ZkVersion;
+import org.apache.bookkeeper.versioning.LongVersion;
 import org.apache.bookkeeper.versioning.Versioned;
 import org.apache.distributedlog.DLMTestUtil;
 import org.apache.distributedlog.TestZooKeeperClientBuilder;
@@ -33,9 +37,6 @@ import org.apache.zookeeper.ZooDefs;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-
-
 
 /**
  * Test Utils.
@@ -121,7 +122,7 @@ public class TestUtils extends ZooKeeperClusterTestCase {
         assertArrayEquals("Data should return as written",
                 rawData, data.getValue());
         assertEquals("Version should be zero",
-                0, ((ZkVersion) data.getVersion()).getZnodeVersion());
+                0L, ((LongVersion) data.getVersion()).getLongVersion());
     }
 
     @Test(timeout = 60000)

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- dependencies -->
-    <bookkeeper.version>4.5.0</bookkeeper.version>
+    <bookkeeper.version>4.6.0-SNAPSHOT</bookkeeper.version>
     <codahale.metrics.version>3.0.1</codahale.metrics.version>
     <commons-cli.version>1.1</commons-cli.version>
     <commons-codec.version>1.6</commons-codec.version>


### PR DESCRIPTION
Descriptions of the changes in this PR:

- Update the bk version to 4.6.0-SNAPSHOT to align the development of 0.6.0
- in bk 4.6.0, ZkVersion is generalized as LongVersion. Change the usage to LongVersion.