### PR TITLE
Issue 219: Exclude files under target directory from apache-rat check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,7 @@
             <exclude>**/dependency-reduced-pom.xml</exclude>
             <exclude>**/org/apache/distributedlog/thrift/*</exclude>
             <exclude>**/logs/*.log</exclude>
+            <exclude>**/target/*</exclude>
             <!-- Git -->
             <exclude>.git/**/*</exclude>
             <exclude>.github/**/*</exclude>


### PR DESCRIPTION
Descriptions of the changes in this PR:

The problem is distributedlog-client and distributedlog-service have been renamed to distributedlog-proxy-client and distributedlog-proxy-server. so those files don't belong to any active modules, so they are not excluded automatically. exclude them manually.