### PR TITLE
Issue 222: post-commit ci job is broken

### DIFF
--- a/website/scripts/publish-website.sh
+++ b/website/scripts/publish-website.sh
@@ -23,7 +23,7 @@
 
 CONTENT_ROOT_DIR=$1
 TMP_DIR=/tmp/distributedlog-site-tmp
-ORIGIN_REPO=$(git remote show apache | grep 'Push  URL' | awk -F// '{print $NF}')
+ORIGIN_REPO=$(git remote show origin | grep 'Push  URL' | awk -F// '{print $NF}')
 # ORIGIN_REPO=$(git remote show origin | grep 'Push  URL' | awk -F// '{print $NF}')
 echo "ORIGIN_REPO: $ORIGIN_REPO"
 


### PR DESCRIPTION
Descriptions of the changes in this PR:

The reason that the post commit ci job is broken is because `git remote show apache` is used in `publish-website.sh` script, but there isn't `apache` branch in CI cloned workspace. we need to change this from `apache` to `origin`.