### PR TITLE
Issue 224: listing logs should exclude <default>

### DIFF
--- a/distributedlog-core/src/main/java/org/apache/distributedlog/util/DLUtils.java
+++ b/distributedlog-core/src/main/java/org/apache/distributedlog/util/DLUtils.java
@@ -279,7 +279,7 @@ public class DLUtils {
      * @return true if it is reserved name, otherwise false.
      */
     public static boolean isReservedStreamName(String name) {
-        return name.startsWith(".");
+        return name.startsWith(".") || name.startsWith("<");
     }
 
     /**


### PR DESCRIPTION
Descriptions of the changes in this PR:

exclude `<default>` from listing logs

(the tests are covered by #227)