### PR TITLE
Make distributedlog compiled with latest bookkeeper version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- dependencies -->
-    <bookkeeper.version>4.6.0-SNAPSHOT</bookkeeper.version>
+    <bookkeeper.version>4.7.0-SNAPSHOT</bookkeeper.version>
     <codahale.metrics.version>3.0.1</codahale.metrics.version>
     <commons-cli.version>1.1</commons-cli.version>
     <commons-codec.version>1.6</commons-codec.version>


### PR DESCRIPTION
Descriptions of the changes in this PR:

There are code changes on PendingReadOp for new bookkeeper api in current master. DistributedLog uses PendingReadOp for some administration tools. So the current master doesn't compile with the latest bookkeeper version. This code change is to fix that.

The change here includes:

- bump bk to 4.7.0-SNAPSHOT (will switch to 4.6.0 after it is released)
- change to use the latest CompletableFuture in latest PendingReadOp. (this change doesn't target at making distributedlog work with new API)