### PR TITLE
Update README status about distributedlog project

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ reliable _real-time_ applications.
 
 _Apache DistributedLog project graduated from Incubator at July 2017. It is now a sub-project of Apache BookKeeper._
 
+The core components of _Apache DistributedLog_ has been merged as part of _Apache BookKeeper_. The development of _Apache DistributedLog_ has been moved under BookKeeper.
+See [BP-26: Move distributedlog library as part of bookkeeper](http://bookkeeper.apache.org/bps/BP-26-move-distributedlog-core-library/) for more details.
+
 ## Features
 
 #### High Performance


### PR DESCRIPTION
Descriptions of the changes in this PR:

As distributedlog modules are merged into Apache BookKeeper, update the `README` status to reflect the project status.

See [BP-26](http://bookkeeper.apache.org/bps/BP-26-move-distributedlog-core-library/) for current status.
